### PR TITLE
Add HLTV demo scraping CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.venv/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# HLTV Demo Scraper
+
+A small command line utility for downloading demo archives from [HLTV.org](https://www.hltv.org/) using
+[Cloudscraper](https://github.com/VeNoMouS/cloudscraper). The tool supports:
+
+- Downloading individual demo IDs, sequential ranges, or IDs read from a file
+- Generating ID files for distributing work across multiple machines
+- Progress bars for each download via `tqdm`
+- Automatic retry logic, error handling, and optional file overwriting
+
+## Installation
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+The CLI exposes two subcommands: `download` and `generate-id-file`.
+
+### Download demos
+
+```bash
+python -m hltv_demo_scraper download --start-id 118700 --end-id 118710 --output-dir demos
+```
+
+You can also mix and match ID sources:
+
+```bash
+python -m hltv_demo_scraper download \
+  --ids-file ids_to_download.txt \
+  --id 118738 --id 118739 \
+  --start-id 118700 --end-id 118705
+```
+
+By default, existing files are skipped. To overwrite, pass `--overwrite`.
+
+### Generate an ID file
+
+```bash
+python -m hltv_demo_scraper generate-id-file 118700 118900 ids_118700_118900.txt
+```
+
+This creates a text file with one demo ID per line, making it simple to split work across machines.
+
+## Notes
+
+- The script uses Cloudscraper to negotiate Cloudflare challenges before streaming the demo file.
+- Each download displays a `tqdm` progress bar indicating the number of bytes written. When the server
+  provides a `Content-Length`, the bar will show the estimated completion percentage.
+- Failed downloads are retried a configurable number of times (`--retries`). At the end of the run,
+  a summary is printed indicating how many demos were downloaded, skipped, missing, or failed.
+
+## Disclaimer
+
+This project was built for digital preservation and assumes you have permission to download the demo
+files. Respect HLTV's terms of service and the rate limits agreed upon with their CDN partner.

--- a/hltv_demo_scraper/__init__.py
+++ b/hltv_demo_scraper/__init__.py
@@ -1,0 +1,4 @@
+"""Utility CLI for downloading HLTV demo archives."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/hltv_demo_scraper/__main__.py
+++ b/hltv_demo_scraper/__main__.py
@@ -1,0 +1,6 @@
+"""Module entry point for ``python -m hltv_demo_scraper``."""
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/hltv_demo_scraper/cli.py
+++ b/hltv_demo_scraper/cli.py
@@ -1,0 +1,187 @@
+"""Command line interface for the HLTV demo scraper."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from .downloader import DemoDownloader, DownloadResult, unique_demo_ids, write_demo_id_file
+
+DEFAULT_OUTPUT_DIR = Path("demos")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Download demo archives from HLTV.org with Cloudscraper and a progress bar.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR). Default: INFO",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    download_parser = subparsers.add_parser(
+        "download",
+        help="Download one or more demos by ID.",
+    )
+    download_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory to save demos (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    download_parser.add_argument(
+        "--ids-file",
+        type=Path,
+        action="append",
+        help="Path to a text file containing demo IDs (one per line). Can be provided multiple times.",
+    )
+    download_parser.add_argument(
+        "--start-id",
+        type=int,
+        help="Start ID for downloading a sequential range of demos (inclusive).",
+    )
+    download_parser.add_argument(
+        "--end-id",
+        type=int,
+        help="End ID for downloading a sequential range of demos (inclusive).",
+    )
+    download_parser.add_argument(
+        "--id",
+        dest="ids",
+        type=int,
+        action="append",
+        help="Download a specific demo ID. Can be provided multiple times.",
+    )
+    download_parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=64 * 1024,
+        help="Chunk size (in bytes) for streaming downloads. Default: 65536.",
+    )
+    download_parser.add_argument(
+        "--retries",
+        type=int,
+        default=3,
+        help="Number of times to retry a failed download. Default: 3.",
+    )
+    download_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Request timeout in seconds for each download attempt. Default: 60.",
+    )
+    download_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite files if they already exist.",
+    )
+
+    id_file_parser = subparsers.add_parser(
+        "generate-id-file",
+        help="Generate a file containing a sequential list of demo IDs.",
+    )
+    id_file_parser.add_argument("start_id", type=int, help="First demo ID (inclusive).")
+    id_file_parser.add_argument("end_id", type=int, help="Last demo ID (inclusive).")
+    id_file_parser.add_argument("output", type=Path, help="Destination file to write IDs to.")
+
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    numeric_level = getattr(logging, level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f"Invalid log level: {level}")
+    logging.basicConfig(level=numeric_level, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    configure_logging(args.log_level)
+
+    if args.command == "generate-id-file":
+        write_demo_id_file(args.start_id, args.end_id, args.output)
+        return 0
+
+    if args.command == "download":
+        demo_ids = _collect_demo_ids(args)
+        if not demo_ids:
+            parser.error("No demo IDs provided. Use --id, --ids-file, or --start-id/--end-id.")
+
+        downloader = DemoDownloader(
+            args.output_dir,
+            chunk_size=args.chunk_size,
+            retries=args.retries,
+            timeout=args.timeout,
+            skip_existing=not args.overwrite,
+        )
+        results = downloader.download_many(demo_ids)
+        _print_summary(results)
+        failed_downloads = [result for result in results if result.status not in {"downloaded", "skipped"}]
+        return 1 if failed_downloads else 0
+
+    parser.error("Unknown command")
+    return 2
+
+
+def _collect_demo_ids(args: argparse.Namespace) -> List[int]:
+    ids: List[int] = []
+    if args.ids:
+        ids.extend(args.ids)
+    if args.ids_file:
+        ids.extend(_load_ids_from_files(args.ids_file))
+    if args.start_id is not None or args.end_id is not None:
+        if args.start_id is None or args.end_id is None:
+            raise SystemExit("--start-id and --end-id must be provided together")
+        if args.end_id < args.start_id:
+            raise SystemExit("--end-id must be greater than or equal to --start-id")
+        ids.extend(range(args.start_id, args.end_id + 1))
+    return unique_demo_ids(ids)
+
+
+def _load_ids_from_files(files: Iterable[Path]) -> List[int]:
+    demo_ids: List[int] = []
+    for file_path in files:
+        with Path(file_path).open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                try:
+                    demo_ids.append(int(stripped))
+                except ValueError as exc:
+                    raise SystemExit(
+                        f"Invalid demo ID '{stripped}' in {file_path} on line {line_number}: {exc}"
+                    ) from exc
+    return demo_ids
+
+
+def _print_summary(results: Iterable[DownloadResult]) -> None:
+    total = 0
+    counts = {"downloaded": 0, "skipped": 0, "not_found": 0, "failed": 0}
+    for result in results:
+        total += 1
+        counts.setdefault(result.status, 0)
+        counts[result.status] += 1
+        if result.status == "failed":
+            logging.error("Failed to download %s: %s", result.demo_id, result.message)
+        elif result.status == "not_found":
+            logging.warning("Demo ID %s was not found", result.demo_id)
+    logging.info(
+        "Summary: %s demos processed (%s downloaded, %s skipped, %s not found, %s failed)",
+        total,
+        counts.get("downloaded", 0),
+        counts.get("skipped", 0),
+        counts.get("not_found", 0),
+        counts.get("failed", 0),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/hltv_demo_scraper/downloader.py
+++ b/hltv_demo_scraper/downloader.py
@@ -1,0 +1,186 @@
+"""Download HLTV demo archives with progress reporting."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+from urllib.parse import unquote
+
+import cloudscraper
+from requests import Response
+from requests.exceptions import RequestException
+from tqdm import tqdm
+
+_LOGGER = logging.getLogger(__name__)
+
+DEMO_URL_TEMPLATE = "https://www.hltv.org/download/demo/{demo_id}"
+
+
+@dataclass
+class DownloadResult:
+    """Represents the outcome of a demo download operation."""
+
+    demo_id: int
+    status: str
+    message: str = ""
+    file_path: Optional[Path] = None
+
+    def __bool__(self) -> bool:  # pragma: no cover - convenience only
+        return self.status == "downloaded"
+
+
+class DemoDownloader:
+    """Download demos from HLTV with Cloudscraper and a progress bar."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        *,
+        chunk_size: int = 64 * 1024,
+        retries: int = 3,
+        timeout: int = 60,
+        skip_existing: bool = True,
+    ) -> None:
+        self.output_dir = Path(output_dir)
+        self.chunk_size = chunk_size
+        self.retries = max(1, retries)
+        self.timeout = timeout
+        self.skip_existing = skip_existing
+        self.scraper = cloudscraper.create_scraper()
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def download_many(self, demo_ids: Iterable[int]) -> List[DownloadResult]:
+        results: List[DownloadResult] = []
+        for demo_id in demo_ids:
+            result = self.download_demo(demo_id)
+            results.append(result)
+        return results
+
+    def download_demo(self, demo_id: int) -> DownloadResult:
+        url = DEMO_URL_TEMPLATE.format(demo_id=demo_id)
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self.retries + 1):
+            try:
+                _LOGGER.debug("Fetching demo %s (attempt %s)", demo_id, attempt)
+                with self.scraper.get(url, timeout=self.timeout, stream=True) as response:
+                    if response.status_code == 404:
+                        return DownloadResult(demo_id, "not_found", "Demo ID does not exist")
+                    response.raise_for_status()
+
+                    filename = self._filename_from_response(response, demo_id)
+                    destination = self.output_dir / filename
+                    if self.skip_existing and destination.exists():
+                        _LOGGER.info("Skipping %s; file already exists", filename)
+                        return DownloadResult(
+                            demo_id,
+                            "skipped",
+                            "File already exists",
+                            destination,
+                        )
+
+                    total_bytes = self._content_length(response)
+                    progress = tqdm(
+                        total=total_bytes,
+                        unit="B",
+                        unit_scale=True,
+                        desc=f"Demo {demo_id}",
+                        leave=False,
+                    )
+                    try:
+                        with destination.open("wb") as file_handle:
+                            for chunk in response.iter_content(chunk_size=self.chunk_size):
+                                if not chunk:
+                                    continue
+                                file_handle.write(chunk)
+                                progress.update(len(chunk))
+                    finally:
+                        progress.close()
+
+                _LOGGER.info("Downloaded %s -> %s", url, destination)
+                return DownloadResult(demo_id, "downloaded", file_path=destination)
+            except RequestException as exc:
+                last_error = exc
+                _LOGGER.warning(
+                    "Error downloading demo %s on attempt %s/%s: %s",
+                    demo_id,
+                    attempt,
+                    self.retries,
+                    exc,
+                )
+        error_message = f"Failed after {self.retries} attempts: {last_error}"
+        _LOGGER.error("%s", error_message)
+        return DownloadResult(demo_id, "failed", error_message)
+
+    @staticmethod
+    def _content_length(response: Response) -> Optional[int]:
+        header_value = response.headers.get("Content-Length")
+        if header_value is None:
+            return None
+        try:
+            return int(header_value)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _filename_from_response(response: Response, demo_id: int) -> str:
+        disposition = response.headers.get("Content-Disposition")
+        if disposition:
+            filename = DemoDownloader._parse_content_disposition(disposition)
+            if filename:
+                return filename
+
+        # Fall back to deriving from the final URL if present.
+        filename = Path(response.url).name.split("?")[0]
+        if filename:
+            return filename
+
+        return f"demo_{demo_id}.rar"
+
+    @staticmethod
+    def _parse_content_disposition(header_value: str) -> Optional[str]:
+        parts = [part.strip() for part in header_value.split(";") if part.strip()]
+        for part in parts[1:]:
+            if "=" not in part:
+                continue
+            key, value = part.split("=", 1)
+            key = key.lower().strip()
+            value = value.strip().strip('"')
+
+            if key == "filename*":
+                # RFC 5987: filename*=UTF-8''encoded-name
+                _, _, encoded_value = value.partition("''")
+                candidate = encoded_value or value
+                return Path(unquote(candidate)).name
+            if key == "filename":
+                return Path(value).name
+        return None
+
+
+def unique_demo_ids(demo_ids: Iterable[int]) -> List[int]:
+    seen = set()
+    ordered_ids: List[int] = []
+    for demo_id in demo_ids:
+        if demo_id in seen:
+            continue
+        seen.add(demo_id)
+        ordered_ids.append(demo_id)
+    return ordered_ids
+
+
+def write_demo_id_file(start_id: int, end_id: int, destination: Path) -> Path:
+    if end_id < start_id:
+        raise ValueError("end_id must be greater than or equal to start_id")
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8") as handle:
+        for demo_id in range(start_id, end_id + 1):
+            handle.write(f"{demo_id}\n")
+    _LOGGER.info(
+        "Wrote %s demo IDs (%s-%s) to %s",
+        end_id - start_id + 1,
+        start_id,
+        end_id,
+        destination,
+    )
+    return destination

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cloudscraper>=1.2.70
+tqdm>=4.64


### PR DESCRIPTION
## Summary
- add a Python CLI package for downloading HLTV demo archives with Cloudscraper
- support ID ranges, ID lists, overwriting, retries, and writeable ID files for splitting work
- document usage and dependencies, and ignore build artefacts

## Testing
- python -m hltv_demo_scraper --help
- python -m hltv_demo_scraper download --help
- python -m hltv_demo_scraper generate-id-file --help
- python -m hltv_demo_scraper generate-id-file 1 3 sample_ids.txt

------
https://chatgpt.com/codex/tasks/task_e_68dcc0cb833083208f3a3a989f80689d